### PR TITLE
Feature: Open New Tab for all Footer Links

### DIFF
--- a/angular/src/app/footer.component.spec.ts
+++ b/angular/src/app/footer.component.spec.ts
@@ -30,7 +30,7 @@ describe('FooterComponent', () => {
     ).toEqual('Terms and conditions');
   });
 
-  it('should render accessibility statement link"]', () => {
+  it('should render accessibility statement link', () => {
     const fixture = TestBed.createComponent(FooterComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
@@ -39,7 +39,7 @@ describe('FooterComponent', () => {
     ).toEqual('Accessibility statement');
   });
 
-  it('should render open government licence link"]', () => {
+  it('should render open government licence link', () => {
     const fixture = TestBed.createComponent(FooterComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
@@ -48,7 +48,7 @@ describe('FooterComponent', () => {
     ).toEqual('Open Government Licence v3.0');
   });
 
-  it('should render crown copyright link"]', () => {
+  it('should render crown copyright link', () => {
     const fixture = TestBed.createComponent(FooterComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;

--- a/angular/src/app/footer.component.ts
+++ b/angular/src/app/footer.component.ts
@@ -11,7 +11,10 @@ import { Component } from '@angular/core';
 
             <ul class="govuk-footer__inline-list">
               <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" routerLink="/terms-and-conditions"
+                <a
+                  class="govuk-footer__link"
+                  routerLink="/terms-and-conditions"
+                  target="_blank"
                   >Terms and conditions</a
                 >
               </li>
@@ -20,6 +23,7 @@ import { Component } from '@angular/core';
                 <a
                   class="govuk-footer__link"
                   routerLink="/accessibility-statement"
+                  target="_blank"
                   >Accessibility statement</a
                 >
               </li>


### PR DESCRIPTION
### Change description ###

- Feature: Clicking terms and conditions link on footer opens a new tab with the terms and conditions page
- Feature: Clicking accessibility statement link on the footer opens a new tab with the accessibility statement page

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
