### PR TITLE
fix: redirect to /login if state not set

### DIFF
--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -76,6 +76,11 @@ app.use((err: HTTPError, req: express.Request, res: express.Response, next: expr
   logger.error(err.message);
   logger.error(JSON.stringify(err));
 
+  if (err.message.includes('checks.state')) {
+    res.redirect('/login');
+    return;
+  }
+
   res.status(err.status || 500);
   res.render('error', { status: err.status || 500, message: err.message });
   next();

--- a/src/main/views/error.njk
+++ b/src/main/views/error.njk
@@ -9,7 +9,7 @@
       <p class="govuk-body">
         {% if status == 401 %}
           You do not have access to view this page.
-        {% elif 'nonce mismatch' in message or 'checks.state' in message  %}
+        {% elif 'nonce mismatch' in message %}
           Your session has timed out or you have tried to access a page without the correct permissions.
         {% elif 'User has not been invited to the portal' == message %}
           You don't currently have access to the portal.
@@ -20,7 +20,6 @@
       <p class="govuk-body">
         {% if status == 401
           or 'nonce mismatch' in message
-          or checks.state in message
           or 'User has not been invited to the portal' == message %}
           You can
           <a class="govuk-link" href="/login">sign in again</a>.


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/S28-2684

### Change description ###

- In case the user bookmarks b2c, redirect the user back to /login to make sure the state is set correctly
