### PR TITLE
Use stg B2C in stg env

### DIFF
--- a/charts/pre-portal/values.stg.template.yaml
+++ b/charts/pre-portal/values.stg.template.yaml
@@ -3,8 +3,6 @@ nodejs:
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}
   environment:
-    REDIS_HOST: pre-portal-{{ .Values.global.environment }}.redis.cache.windows.net
     PRE_API_URL: https://sds-api-mgmt.staging.platform.hmcts.net/pre-api
     PORTAL_URL: https://pre-portal-staging.staging.platform.hmcts.net
-    B2C_BASE_URL: https://hmctsdevextid.b2clogin.com/hmctsdevextid.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_SIGNUP_SIGNIN
-    B2C_END_SESSION_ENDPOINT: https://hmctsdevextid.b2clogin.com/hmctsdevextid.onmicrosoft.com/b2c_1a_signup_signin/oauth2/v2.0/logout
+    B2C_APP_CLIENT_ID: d20a7462-f222-46b8-a363-d2e30eb274eb


### PR DESCRIPTION

### JIRA ticket(s)

- S28-2756

### Change description
This will update the staging-staging environment (the one which is used as path to live rather than live-like staging) to use the staging B2C. The PR to update live-like staging is here: https://github.com/hmcts/sds-flux-config/pull/4827 