### PR TITLE
Revert "include js when env var set for dynatrace jstag"

### DIFF
--- a/charts/pre-portal/Chart.yaml
+++ b/charts/pre-portal/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: '1.0'
 description: A Helm chart for pre-portal App
 name: pre-portal
 home: https://github.com/hmcts/pre-portal
-version: 0.0.19
+version: 0.0.18
 dependencies:
   - name: nodejs
     version: 3.1.1

--- a/src/main/modules/properties-volume/index.ts
+++ b/src/main/modules/properties-volume/index.ts
@@ -55,7 +55,6 @@ export class PropertiesVolume {
       this.setSecret('secrets.pre-hmctskv.b2c-test-login-email', 'b2c.testLogin.email');
       this.setSecret('secrets.pre-hmctskv.b2c-test-login-password', 'b2c.testLogin.password');
       this.setSecret('secrets.pre-hmctskv.media-kind-player-key', 'pre.mediaKindPlayerKey');
-      server.locals.dynatrace_jstag = process.env.DYNATRACE_JSTAG ?? 'false';
     } else {
       this.logger.info('Loading properties from .env file');
       require('dotenv').config();

--- a/src/main/views/template.njk
+++ b/src/main/views/template.njk
@@ -117,7 +117,4 @@
       ]
     }
   }) }}
-  {% if dynatrace_jstag %}
-    <script type="text/javascript" src="{{ dynatrace_jstag }}" crossorigin="anonymous"></script>
-  {% endif %}
 {% endblock %}


### PR DESCRIPTION
Reverts hmcts/pre-portal#533

I'm wondering if this is responsible for S28-3462 as the first occurrences started on the same day. On the face of it, it seems unlikely but the timing is very coincidental and given it contains 'false'. We don't currently use Dynatrace and are waiting new js snippets from them so In suggest we remove this code and monitor AppInsights for changes.