### PR TITLE
Check for apm === true rather than 'on'

### DIFF
--- a/src/main/assets/js/cookie.js
+++ b/src/main/assets/js/cookie.js
@@ -12,7 +12,7 @@ cookieManager.on('UserPreferencesSaved', preferences => {
   dataLayer.push({ event: 'Cookie Preferences', cookiePreferences: preferences });
 
   if (dtrum !== undefined) {
-    if (preferences.apm === 'on') {
+    if (preferences.apm === true) {
       dtrum.enable();
       dtrum.enableSessionReplay();
     } else {


### PR DESCRIPTION
Seems Dynatrace RUM is not working and from the dev console I can see `Setting preferences to: {"apm":true}` but the code currently checks for `=== 'on'` so this change will check for `=== true` and hopefully fix the issue.