### PR TITLE
S28-4782/edit-request-status-ui

### DIFF
--- a/src/main/routes/browse.ts
+++ b/src/main/routes/browse.ts
@@ -34,6 +34,100 @@ type BrowseRecording = Recording & {
   row_id?: string;
 };
 
+const buildBrowseRows = (recordings: Recording[]): BrowseRecording[] => {
+  // Find which edit requests should NOT show as pending rows because they've already been applied.
+  const nonPendingEditRequestIds = new Set<string>();
+  for (const recording of recordings) {
+    if (recording.version > 1) {
+      const editRequestId = getEditRequestId(recording.edit_instructions);
+      if (editRequestId) nonPendingEditRequestIds.add(editRequestId);
+    }
+  }
+
+  // Look up an edit request's current status by searching all recordings.
+  const findEditRequestStatus = (editRequestId: string): string | undefined => {
+    for (const recording of recordings) {
+      for (const editRequest of recording.edit_requests || []) {
+        if (editRequest.id === editRequestId) return editRequest.status;
+      }
+    }
+  };
+
+  // Create a display row, apply formatting and property overrides.
+  const createBrowseRow = (recording: Recording, overrides?: Partial<BrowseRecording>): BrowseRecording => ({
+    ...recording,
+    ...overrides,
+    capture_session: {
+      ...recording.capture_session,
+      case_closed_at: convertIsoToDate(recording.capture_session.case_closed_at),
+    },
+  });
+
+  // Group recordings by their root ID (V1 uses its own ID. Pending and V2+ uses parent_recording_id).
+  const recordingsByRootId = new Map<string, Recording[]>();
+  for (const recording of recordings) {
+    const rootId = recording.parent_recording_id || recording.id;
+    if (!recordingsByRootId.has(rootId)) recordingsByRootId.set(rootId, []);
+    recordingsByRootId.get(rootId)!.push(recording);
+  }
+
+  const result: BrowseRecording[] = [];
+
+  // Process each group of related recordings.
+  for (const recordingsInGroup of recordingsByRootId.values()) {
+    const completedEditRequestRows: BrowseRecording[] = [];  // V2, V3, ... (Completed edits)
+    const pendingEditRequestRows: BrowseRecording[] = [];    // Edits in progress (submitted, approved, etc)
+    const draftEditRequestRows: BrowseRecording[] = [];      // Edits with status 'DRAFT'
+    let originalRecording: BrowseRecording | undefined;
+
+    // Add rows for each real recording in the group.
+    for (const recording of recordingsInGroup) {
+      let statusToDisplay: string | undefined;
+      if (recording.version === 1) {
+        statusToDisplay = undefined; // Original recordings don't show an edit status.
+      } else {
+        const editRequestId = getEditRequestId(recording.edit_instructions);
+        statusToDisplay = (editRequestId ? findEditRequestStatus(editRequestId) : undefined) ?? recording.edit_status;
+      }
+
+      const recordingRow = createBrowseRow(recording, { edit_status: statusToDisplay });
+
+      if (recording.version === 1) {
+        originalRecording = recordingRow;
+      } else {
+        completedEditRequestRows.push(recordingRow);
+      }
+
+      // Create rows for edit requests that aren't complete.
+      for (const editRequest of recording.edit_requests || []) {
+        if (editRequest.status === 'COMPLETE') continue;
+        if (nonPendingEditRequestIds.has(editRequest.id)) continue;
+
+        const editRequestRow = createBrowseRow(recording, {
+          version: (recording.total_version_count ?? recording.version) + 1,
+          edit_status: editRequest.status,
+          row_id: `${recording.id}-${editRequest.id}`,
+        });
+
+        if (editRequest.status === 'DRAFT') {
+          draftEditRequestRows.push(editRequestRow);
+        } else {
+          pendingEditRequestRows.push(editRequestRow);
+        }
+      }
+    }
+
+    // Sort completed edit request rows by version number (newest first).
+    completedEditRequestRows.sort((a, b) => b.version - a.version);
+
+    // Add rows in order: completed edits → pending edits → drafts → original.
+    result.push(...completedEditRequestRows, ...pendingEditRequestRows, ...draftEditRequestRows);
+    if (originalRecording) result.push(originalRecording);
+  }
+
+  return result;
+};
+
 export default function (app: Application): void {
   app.get('/browse', requiresAuth(), async (req, res) => {
     const logger = Logger.getLogger('browse-route');
@@ -80,44 +174,7 @@ export default function (app: Application): void {
       SessionUser.getLoggedInUserProfile(req).app_access.filter(role => role.role.name === UserLevel.SUPER_USER)
         .length > 0;
 
-    // Collect all edit request statuses from recordings (V1 recordings carry these)
-    const editStatusByRequestId = new Map<string, string>();
-    for (const recording of recordings) {
-      for (const edit of recording.edit_requests || []) {
-        editStatusByRequestId.set(edit.id, edit.status);
-      }
-    }
-
-    const resolveEditStatus = (recording: Recording): string | undefined => {
-      if (recording.version === 1) return undefined; // V1 edit_status is wrong — it refers to the latest edit, not this version
-      const editRequestId = getEditRequestId(recording.edit_instructions);
-      return editStatusByRequestId.get(editRequestId || '') ?? recording.edit_status;
-    };
-
-    const getDraftRows = (recording: Recording, base: BrowseRecording): BrowseRecording[] => {
-      return (recording.edit_requests || [])
-        .filter(e => e.status === 'DRAFT')
-        .map(edit => ({
-          ...base,
-          version: recording.version + 1,
-          edit_status: 'DRAFT',
-          row_id: `${recording.id}-${edit.id}`,
-        }));
-    };
-
-    // Build the final list: each recording + synthetic rows for any DRAFT edit requests
-    const recordingsForView: BrowseRecording[] = recordings.flatMap(recording => {
-      const base: BrowseRecording = {
-        ...recording,
-        capture_session: {
-          ...recording.capture_session,
-          case_closed_at: convertIsoToDate(recording.capture_session.case_closed_at),
-        },
-        edit_status: resolveEditStatus(recording),
-      };
-
-      return [...getDraftRows(recording, base), base];
-    });
+    const recordingsForView = buildBrowseRows(recordings);
 
     const paginationLinks = {
       previous: {},

--- a/src/main/routes/browse.ts
+++ b/src/main/routes/browse.ts
@@ -1,5 +1,5 @@
 import { PreClient } from '../services/pre-api/pre-client';
-import { SearchRecordingsRequest } from '../services/pre-api/types';
+import { Recording, SearchRecordingsRequest } from '../services/pre-api/types';
 import { SessionUser } from '../services/session-user/session-user';
 import { UserLevel } from '../types/user-level';
 
@@ -20,9 +20,24 @@ export const convertIsoToDate = (isoString?: string): string | undefined => {
   });
 };
 
+export const getEditRequestId = (editInstructions?: string): string | undefined => {
+  if (!editInstructions) return;
+  try {
+    const parsed = JSON.parse(editInstructions);
+    return parsed.editRequestId || parsed.edit_request_id || parsed.editRequest?.id;
+  } catch {
+    return;
+  }
+};
+
+type BrowseRecording = Recording & {
+  row_id?: string;
+};
+
 export default function (app: Application): void {
   app.get('/browse', requiresAuth(), async (req, res) => {
     const logger = Logger.getLogger('browse-route');
+    const userPortalId = await SessionUser.getLoggedInUserPortalId(req);
     const userProfileForCjsm = SessionUser.getLoggedInUserProfile(req);
     const primaryEmail = (userProfileForCjsm.user.email || '').toLowerCase();
     const alternativeEmail = (userProfileForCjsm.user.alternative_email || '').toLowerCase();
@@ -54,10 +69,7 @@ export default function (app: Application): void {
       size: 10,
     };
 
-    const { recordings, pagination } = await client.getRecordings(
-      await SessionUser.getLoggedInUserPortalId(req),
-      request
-    );
+    const { recordings, pagination } = await client.getRecordings(userPortalId, request);
 
     // Example 9 pages: <Previous 0 ... 2 3 |4| 5 6 ... 8 Next>
     // Page starts at 0
@@ -68,13 +80,44 @@ export default function (app: Application): void {
       SessionUser.getLoggedInUserProfile(req).app_access.filter(role => role.role.name === UserLevel.SUPER_USER)
         .length > 0;
 
-    const updatedRecordings = recordings.map(recording => ({
-      ...recording,
-      capture_session: {
-        ...recording.capture_session,
-        case_closed_at: convertIsoToDate(recording.capture_session.case_closed_at),
-      },
-    }));
+    // Collect all edit request statuses from recordings (V1 recordings carry these)
+    const editStatusByRequestId = new Map<string, string>();
+    for (const recording of recordings) {
+      for (const edit of recording.edit_requests || []) {
+        editStatusByRequestId.set(edit.id, edit.status);
+      }
+    }
+
+    const resolveEditStatus = (recording: Recording): string | undefined => {
+      if (recording.version === 1) return undefined; // V1 edit_status is wrong — it refers to the latest edit, not this version
+      const editRequestId = getEditRequestId(recording.edit_instructions);
+      return editStatusByRequestId.get(editRequestId || '') ?? recording.edit_status;
+    };
+
+    const getDraftRows = (recording: Recording, base: BrowseRecording): BrowseRecording[] => {
+      return (recording.edit_requests || [])
+        .filter(e => e.status === 'DRAFT')
+        .map(edit => ({
+          ...base,
+          version: recording.version + 1,
+          edit_status: 'DRAFT',
+          row_id: `${recording.id}-${edit.id}`,
+        }));
+    };
+
+    // Build the final list: each recording + synthetic rows for any DRAFT edit requests
+    const recordingsForView: BrowseRecording[] = recordings.flatMap(recording => {
+      const base: BrowseRecording = {
+        ...recording,
+        capture_session: {
+          ...recording.capture_session,
+          case_closed_at: convertIsoToDate(recording.capture_session.case_closed_at),
+        },
+        edit_status: resolveEditStatus(recording),
+      };
+
+      return [...getDraftRows(recording, base), base];
+    });
 
     const paginationLinks = {
       previous: {},
@@ -136,7 +179,7 @@ export default function (app: Application): void {
     }
 
     let title = 'Recordings';
-    if (updatedRecordings.length > 0) {
+    if (recordings.length > 0) {
       title = `Recordings ${pagination.currentPage * pagination.size + 1} to ${Math.min(
         (pagination.currentPage + 1) * pagination.size,
         pagination.totalElements
@@ -144,7 +187,7 @@ export default function (app: Application): void {
     }
 
     res.render('browse', {
-      recordings: updatedRecordings,
+      recordings: recordingsForView,
       paginationLinks,
       title,
       user: SessionUser.getLoggedInUserProfile(req).user,

--- a/src/main/services/pre-api/types.ts
+++ b/src/main/services/pre-api/types.ts
@@ -55,6 +55,7 @@ export interface Recording {
   participants: Participant[];
   edit_status?: string;
   edit_requests?: { id: string; status: string }[];
+  total_version_count?: number;
 }
 
 export interface Participant {

--- a/src/main/services/pre-api/types.ts
+++ b/src/main/services/pre-api/types.ts
@@ -54,6 +54,7 @@ export interface Recording {
   is_test_case: boolean;
   participants: Participant[];
   edit_status?: string;
+  edit_requests?: { id: string; status: string }[];
 }
 
 export interface Participant {

--- a/src/main/views/browse.njk
+++ b/src/main/views/browse.njk
@@ -105,8 +105,12 @@
               <td class="govuk-table__cell">
                 {% if recording.version == 1 %}
                   Original
-                {% else %}
+                {% elif recording.edit_status == "DRAFT" %}
+                  Draft
+                {% elif recording.edit_status == "COMPLETE" %}
                   {{ recording.version }}
+                {% else %}
+                  Pending
                 {% endif %}
               </td>
               <td class="govuk-table__cell">
@@ -129,15 +133,15 @@
                     <strong class="govuk-tag govuk-tag--grey">
                       Draft
                     </strong>
-                  {% elif recording.edit_status == "SUBMITTED" %}
-                    <strong class="govuk-tag govuk-tag--blue">
-                      Submitted
-                    </strong>
                   {% elif recording.edit_status == "REJECTED" %}
                     <strong class="govuk-tag govuk-tag--red">
                       Rejected
                     </strong>
-                  {% elif recording.edit_status in ["APPROVED", "PENDING", "PROCESSING", "COMPLETE"] %}
+                  {% elif recording.edit_status in ["SUBMITTED","APPROVED", "PENDING", "PROCESSING"] %}
+                    <strong class="govuk-tag govuk-tag--blue">
+                      {{ recording.edit_status | capitalize }}
+                    </strong>
+                  {% elif recording.edit_status == "COMPLETE" %}
                     <strong class="govuk-tag govuk-tag--green">
                       {{ recording.edit_status | capitalize }}
                     </strong>
@@ -150,14 +154,14 @@
                   {% endif %}
                 </td>
                 <td class="govuk-table__cell">
-                  {% if recording.version == 1 or recording.edit_status in ["APPROVED", "COMPLETE"] %}
+                  {% if recording.version == 1 or recording.edit_status == "COMPLETE" %}
                     <a class="govuk-link" href="/watch/{{ recording.id }}">
                       Play
                       <span class="sr-only" hidden>video case ref {{ recording.case_reference }}</span>
                     </a>
                   {% elif recording.edit_status == "DRAFT" %}
                     <a class="govuk-link" href="/edit-request/{{ recording.id }}">Edit</a>
-                  {% elif recording.edit_status in ["SUBMITTED", "REJECTED", "PROCESSING", "PENDING", "ERROR"] %}
+                  {% elif recording.edit_status in ["APPROVED", "SUBMITTED", "REJECTED", "PROCESSING", "PENDING", "ERROR"] %}
                     <a class="govuk-link" href="/edit-request/{{ recording.id }}/view">View</a>
                   {% endif %}
                 </td>

--- a/src/main/views/browse.njk
+++ b/src/main/views/browse.njk
@@ -58,7 +58,7 @@
           <th scope="col" class="govuk-table__header">Witness</th>
           <th scope="col" class="govuk-table__header">Defendants</th>
           <th scope="col" class="govuk-table__header">Version</th>
-          <th scope="col" class="govuk-table__header">Status</th>
+          <th scope="col" class="govuk-table__header">Case Status</th>
           {% if enableAutomatedEditing == true %}
           <th scope="col" class="govuk-table__header">Edit Status</th>
           <th scope="col" class="govuk-table__header">Action</th>
@@ -78,7 +78,7 @@
           {% for recording in recordings %}
             <tr
               class="govuk-table__row"
-              id="recording-{{ recording.id }}">
+              id="recording-{{ recording.row_id or recording.id }}">
               <td class="govuk-table__cell" style="position: sticky; left: 0; z-index: 1; background-color: #ffffff;">
                 {{ recording.case_reference }}
               </td>
@@ -103,7 +103,7 @@
                 {% endfor %}
               </td>
               <td class="govuk-table__cell">
-                {% if recording.version == "1" %}
+                {% if recording.version == 1 %}
                   Original
                 {% else %}
                   {{ recording.version }}
@@ -124,41 +124,42 @@
               </td>
               {% if enableAutomatedEditing == true %}
                 <td class="govuk-table__cell">
-                  {% if recording.edit_status == "DRAFT" %}
+                  {% if recording.version == 1 %}
+                  {% elif recording.edit_status == "DRAFT" %}
                     <strong class="govuk-tag govuk-tag--grey">
                       Draft
                     </strong>
-                  {% endif %}
-                  {% if recording.edit_status == "SUBMITTED" %}
+                  {% elif recording.edit_status == "SUBMITTED" %}
                     <strong class="govuk-tag govuk-tag--blue">
                       Submitted
                     </strong>
-                  {% endif %}
-                  {% if recording.edit_status == "REJECTED" %}
+                  {% elif recording.edit_status == "REJECTED" %}
                     <strong class="govuk-tag govuk-tag--red">
                       Rejected
                     </strong>
-                  {% endif %}
-                  {% if recording.edit_status in ["APPROVED", "PENDING", "PROCESSING", "COMPLETE", "ERROR"] %}
+                  {% elif recording.edit_status in ["APPROVED", "PENDING", "PROCESSING", "COMPLETE"] %}
                     <strong class="govuk-tag govuk-tag--green">
-                      Approved
+                      {{ recording.edit_status | capitalize }}
                     </strong>
+                  {% elif recording.edit_status == "ERROR" %}
+                    <strong class="govuk-tag govuk-tag--red">
+                      Error
+                    </strong>
+                  {% else %}
+
                   {% endif %}
                 </td>
                 <td class="govuk-table__cell">
-                  <div style="display: inline-flex; flex-wrap: wrap;">
-                  <a class="govuk-link" href="/watch/{{ recording.id }}">
-                                        Play
-                                        <span class="sr-only" hidden>video case ref {{ recording.case_reference}}</span>
-                                      </a>
-                    {% if recording.version == 1 %}
-                      {% if recording.edit_status not in ['DRAFT', 'REJECTED', 'COMPLETE', undefined] %}
-                        <a class="govuk-link" href="/edit-request/{{ recording.id }}/view">View</a>
-                      {% else %}
-                        <a class="govuk-link" href="/edit-request/{{ recording.id }}">Edit</a>
-                      {% endif %}
-                    {% endif %}
-                  </div>
+                  {% if recording.version == 1 or recording.edit_status in ["APPROVED", "COMPLETE"] %}
+                    <a class="govuk-link" href="/watch/{{ recording.id }}">
+                      Play
+                      <span class="sr-only" hidden>video case ref {{ recording.case_reference }}</span>
+                    </a>
+                  {% elif recording.edit_status == "DRAFT" %}
+                    <a class="govuk-link" href="/edit-request/{{ recording.id }}">Edit</a>
+                  {% elif recording.edit_status in ["SUBMITTED", "REJECTED", "PROCESSING", "PENDING", "ERROR"] %}
+                    <a class="govuk-link" href="/edit-request/{{ recording.id }}/view">View</a>
+                  {% endif %}
                 </td>
               {% endif %}
               {% if enableAutomatedEditing == false %}

--- a/src/test/unit/routes/browse.test.ts
+++ b/src/test/unit/routes/browse.test.ts
@@ -228,7 +228,7 @@ describe('Browse route', () => {
     );
   });
 
-  test('should render the version number for later versions', async () => {
+  test('should render the version number for complete later versions', async () => {
     const app = require('express')();
     new Nunjucks(false).enableFor(app);
     const request = require('supertest');
@@ -238,6 +238,7 @@ describe('Browse route', () => {
         id: 'updated-version',
         case_reference: 'CASE-V2',
         version: 2,
+        edit_status: 'COMPLETE',
       },
     ];
 
@@ -256,7 +257,7 @@ describe('Browse route', () => {
     );
   });
 
-  test('should use edit_status from recording for V2+ versions', async () => {
+  test('should show Pending for non-complete V2+ versions', async () => {
     const app = require('express')();
     new Nunjucks(false).enableFor(app);
     const request = require('supertest');
@@ -282,7 +283,7 @@ describe('Browse route', () => {
 
     const text = response.text.replace(/\s+/g, ' ').trim();
     expect(text).toContain('CASE-V2');
-    expect(text).toContain('<td class="govuk-table__cell"> 2 </td>');
+    expect(text).toContain('<td class="govuk-table__cell"> Pending </td>');
   });
 
   test('should show a draft version row when recording has a DRAFT edit request', async () => {
@@ -296,6 +297,7 @@ describe('Browse route', () => {
         id: 'source-v1',
         case_reference: 'CASE-DRAFT',
         version: 1,
+        total_version_count: 1,
         edit_requests: [
           { id: 'draft-request-1', status: 'DRAFT' },
         ],
@@ -312,7 +314,7 @@ describe('Browse route', () => {
 
     const text = response.text.replace(/\s+/g, ' ').trim();
     expect(text).toContain('recording-source-v1-draft-request-1');
-    expect(text).toContain('<td class="govuk-table__cell"> 2 </td>');
+    expect(text).toContain('<td class="govuk-table__cell"> Draft </td>');
   });
 });
 

--- a/src/test/unit/routes/browse.test.ts
+++ b/src/test/unit/routes/browse.test.ts
@@ -20,10 +20,10 @@ jest.mock('express-openid-connect', () => {
 jest.mock('../../../main/services/session-user/session-user', () => {
   return {
     SessionUser: {
-      getLoggedInUserPortalId: jest.fn().mockImplementation((req: Express.Request) => {
+      getLoggedInUserPortalId: jest.fn().mockImplementation(() => {
         return '123';
       }),
-      getLoggedInUserProfile: jest.fn().mockImplementation((req: Express.Request) => {
+      getLoggedInUserProfile: jest.fn().mockImplementation(() => {
         return mockeduser as UserProfile;
       }),
     },
@@ -33,6 +33,7 @@ describe('Browse route', () => {
   beforeAll(() => {
     reset();
   });
+
 
   test('browse renders the browse template', async () => {
     jest.setTimeout(65000); // seems to be a slow page in tests for some reason
@@ -253,6 +254,65 @@ describe('Browse route', () => {
     expect(text).toMatch(
       /id="recording-updated-version"[\s\S]*?<td class="govuk-table__cell" style="position: sticky; left: 0; z-index: 1; background-color: #ffffff;"> CASE-V2 <\/td>[\s\S]*?<td class="govuk-table__cell"> 2 <\/td>/
     );
+  });
+
+  test('should use edit_status from recording for V2+ versions', async () => {
+    const app = require('express')();
+    new Nunjucks(false).enableFor(app);
+    const request = require('supertest');
+
+    const recordings = [
+      {
+        ...mockRecordings[0],
+        id: '22222222-2222-2222-2222-222222222222',
+        parent_recording_id: 'parentId',
+        case_reference: 'CASE-V2',
+        version: 2,
+        edit_status: 'APPROVED',
+      },
+    ];
+
+    mockGetRecordings(recordings);
+
+    const browse = require('../../../main/routes/browse').default;
+    browse(app);
+
+    const response = await request(app).get('/browse');
+    expect(response.status).toEqual(200);
+
+    const text = response.text.replace(/\s+/g, ' ').trim();
+    expect(text).toContain('CASE-V2');
+    expect(text).toContain('<td class="govuk-table__cell"> 2 </td>');
+  });
+
+  test('should show a draft version row when recording has a DRAFT edit request', async () => {
+    const app = require('express')();
+    new Nunjucks(false).enableFor(app);
+    const request = require('supertest');
+
+    const recordings = [
+      {
+        ...mockRecordings[0],
+        id: 'source-v1',
+        case_reference: 'CASE-DRAFT',
+        version: 1,
+        edit_requests: [
+          { id: 'draft-request-1', status: 'DRAFT' },
+        ],
+      },
+    ];
+
+    mockGetRecordings(recordings);
+
+    const browse = require('../../../main/routes/browse').default;
+    browse(app);
+
+    const response = await request(app).get('/browse');
+    expect(response.status).toEqual(200);
+
+    const text = response.text.replace(/\s+/g, ' ').trim();
+    expect(text).toContain('recording-source-v1-draft-request-1');
+    expect(text).toContain('<td class="govuk-table__cell"> 2 </td>');
   });
 });
 


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->

<!--
### JIRA ticket(s)

- S28-4782
-->

### Change description

 - Added sorting and status details to the /browse page UI

 - Recordings and Edit Requests are now sorted in the following way:
 - Top to bottom, recordings are grouped by case ref (V2+ recordings -> submitted/approved/pending -> V1 original recording). Groups are sorted by most recent recording.created_at date.

<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->

<!--
> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**

-
-
-->

<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change.

**Breaking change description**

-
-
-->
