### PR TITLE
Use super user access for browse recordings

### DIFF
--- a/src/main/routes/browse.ts
+++ b/src/main/routes/browse.ts
@@ -54,7 +54,7 @@ export default function (app: Application): void {
     };
 
     const { recordings, pagination } = await client.getRecordings(
-      await SessionUser.getLoggedInUserPortalId(req),
+      await SessionUser.getLoggedInUserBrowseId(req),
       request
     );
 

--- a/src/main/services/session-user/session-user.ts
+++ b/src/main/services/session-user/session-user.ts
@@ -1,4 +1,5 @@
 import { UserProfile } from '../../types/user-profile';
+import { UserLevel } from '../../types/user-level';
 import { PreClient } from '../pre-api/pre-client';
 
 export class SessionUser {
@@ -18,6 +19,17 @@ export class SessionUser {
     await client.getActiveUserByEmail(user.user.email);
 
     return user.portal_access[0].id;
+  }
+
+  public static async getLoggedInUserBrowseId(req: Express.Request): Promise<string> {
+    const user = this.getLoggedInUserProfile(req);
+    const superUserAccess = user.app_access?.find(access => access.active && access.role.name === UserLevel.SUPER_USER);
+
+    if (superUserAccess) {
+      return superUserAccess.id;
+    }
+
+    return this.getLoggedInUserPortalId(req);
   }
 
   public static getLoggedInUserProfile(req: Express.Request): UserProfile {

--- a/src/test/steps/common.ts
+++ b/src/test/steps/common.ts
@@ -25,29 +25,14 @@ When('I am on the {string} page', (path: string) => {
   I.amOnPage(url.toString());
 });
 
-Then('I sign in with valid credentials as the test user', () => {
+Then('I sign in with valid credentials as the test user', async () => {
   const login = config.b2c.testLogin;
-  signIn(login.email as string, login.password as string);
-
-  // handle dodgy B2C login where bounces back to login form 1 time...sometimes.
-  I.grabCurrentUrl().then(url => {
-    if (url.includes('/authorize')) {
-      const login = config.b2c.testLogin;
-      signIn(login.email as string, login.password as string);
-    }
-  });
+  await signInWithRetry(login.email as string, login.password as string);
 });
 
-Then('I sign in with valid credentials as a super user', () => {
+Then('I sign in with valid credentials as a super user', async () => {
   const login = config.b2c.testSuperUserLogin;
-  signIn(login.email as string, login.password as string);
-
-  I.grabCurrentUrl().then(url => {
-    if (url.includes('/authorize')) {
-      const login = config.b2c.testSuperUserLogin;
-      signIn(login.email as string, login.password as string);
-    }
-  });
+  await signInWithRetry(login.email as string, login.password as string);
 });
 
 Then('I accept the terms and conditions if I need to', async () => {
@@ -78,25 +63,18 @@ When('I open the navigation menu', async () => {
   I.click('#navToggle');
 });
 
-Then('I enter a valid email address', () => {
+Then('I enter a valid email address', async () => {
   const login = config.b2c.testLogin;
-  sendVerifictionCode(login.email as string);
+  await sendVerifictionCode(login.email as string);
 });
 
-Then('I sign in with an unknown user', () => {
-  signIn('email@hmcts.net', 'this is a password');
+Then('I sign in with an unknown user', async () => {
+  await signInWithRetry('email@hmcts.net', 'this is a password');
 });
 
-Then('I sign in with the wrong password', () => {
+Then('I sign in with the wrong password', async () => {
   const login = config.b2c.testLogin;
-  signIn(login.email as string, 'this is not the password');
-
-  // handle dodgy B2C login where bounces back to login form 1 time...sometimes.
-  I.grabCurrentUrl().then(url => {
-    if (url.includes('/authorize')) {
-      signIn(login.email as string, 'this is not the password');
-    }
-  });
+  await signInWithRetry(login.email as string, 'this is not the password');
 });
 
 When('I click on play on a browse page', () => {
@@ -133,19 +111,36 @@ Then('recording is played', async () => {
   I.say('Video is playing successfully!');
 });
 
-function signIn(emailAddress: string, password: string) {
-  fillFieldWhenReady('signInName', emailAddress);
-  fillFieldWhenReady('password', password);
-  I.click('Sign in');
+async function signInWithRetry(emailAddress: string, password: string) {
+  await signIn(emailAddress, password);
+
+  // B2C occasionally bounces back to the login form once. Retry only when the form is still present.
+  await I.wait(3);
+  const shouldRetry = await I.executeScript(() => {
+    const url = window.location.href;
+    return (
+      url.includes('/authorize') && !!document.querySelector('#signInName') && !!document.querySelector('#password')
+    );
+  });
+
+  if (shouldRetry) {
+    await signIn(emailAddress, password);
+  }
 }
 
-function sendVerifictionCode(emailAddress: string) {
-  fillFieldWhenReady('email', emailAddress);
-  I.click('Send verification code');
+async function signIn(emailAddress: string, password: string) {
+  await fillFieldWhenReady('signInName', emailAddress);
+  await fillFieldWhenReady('password', password);
+  await I.click('Sign in');
 }
 
-function fillFieldWhenReady(id: string, value: string, timeout = 5) {
+async function sendVerifictionCode(emailAddress: string) {
+  await fillFieldWhenReady('email', emailAddress);
+  await I.click('Send verification code');
+}
+
+async function fillFieldWhenReady(id: string, value: string, timeout = 5) {
   const locator = { id: id };
-  I.waitForElement(locator, timeout);
-  I.fillField(locator, value);
+  await I.waitForElement(locator, timeout);
+  await I.fillField(locator, value);
 }

--- a/src/test/unit/routes/browse.test.ts
+++ b/src/test/unit/routes/browse.test.ts
@@ -23,6 +23,9 @@ jest.mock('../../../main/services/session-user/session-user', () => {
       getLoggedInUserPortalId: jest.fn().mockImplementation((req: Express.Request) => {
         return '123';
       }),
+      getLoggedInUserBrowseId: jest.fn().mockImplementation((req: Express.Request) => {
+        return 'super-user-access-id';
+      }),
       getLoggedInUserProfile: jest.fn().mockImplementation((req: Express.Request) => {
         return mockeduser as UserProfile;
       }),
@@ -52,6 +55,10 @@ describe('Browse route', () => {
     expect(response.text).toContain('legitimate need and having full authorisation.');
     expect(response.text).toContain('Laptop and Desktop devices only.');
     expect(response.text).toContain('<a href="/logout" class="govuk-back-link">Sign out</a>');
+    expect(PreClient.prototype.getRecordings).toHaveBeenCalledWith(
+      'super-user-access-id',
+      expect.objectContaining({ size: 10 })
+    );
   });
 
   test('should return 500', async () => {

--- a/src/test/unit/session-user/session-user.test.ts
+++ b/src/test/unit/session-user/session-user.test.ts
@@ -52,6 +52,28 @@ describe('Session Users', () => {
     expect(user).toBe('3fa85f64-5717-4562-b3fc-2c963f66afa6');
   });
 
+  test('getLoggedInUserBrowseId uses active super user app access when available', async () => {
+    const req = createRequest();
+    req['__session'] = {
+      userProfile: mockeduser as UserProfile,
+    };
+    const user = await SessionUser.getLoggedInUserBrowseId(req);
+    expect(user).toBe('5000e766-b50d-4473-85b2-0bb54785c169');
+  });
+
+  test('getLoggedInUserBrowseId falls back to portal access when super user app access is inactive', async () => {
+    const req = createRequest();
+    const userProfile = {
+      ...mockeduser,
+      app_access: mockeduser.app_access.map(access => ({ ...access, active: false })),
+    } as UserProfile;
+    req['__session'] = {
+      userProfile,
+    };
+    const user = await SessionUser.getLoggedInUserBrowseId(req);
+    expect(user).toBe('3fa85f64-5717-4562-b3fc-2c963f66afa6');
+  });
+
   test('getLoggedInUserProfile no session', () => {
     const t = () => {
       SessionUser.getLoggedInUserProfile({} as Express.Request);


### PR DESCRIPTION
## What changed
- Use an active Super User app access id for /browse recording searches when the logged-in user has one.
- Fall back to the portal access id for normal portal users.
- Add unit coverage for browse access id selection and the browse route API client call.

## Why
Portal access is authenticated by PRE API as ROLE_LEVEL_3, so re-encoded recordings are hidden. Super users need /browse requests to authenticate with their Super User app access id so all versions are returned.