### PR TITLE
S28-5082 - pin lower brace-expansion versions

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -9337,20 +9337,20 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["brace-expansion", [\
-      ["npm:1.1.13", {\
-        "packageLocation": "./.yarn/cache/brace-expansion-npm-1.1.13-551b297c64-b5f4329fdb.zip/node_modules/brace-expansion/",\
+      ["npm:1.1.17", {\
+        "packageLocation": "./.yarn/cache/brace-expansion-npm-1.1.17-52d7585d9f-1e2f59433d.zip/node_modules/brace-expansion/",\
         "packageDependencies": [\
           ["balanced-match", "npm:1.0.2"],\
-          ["brace-expansion", "npm:1.1.13"],\
+          ["brace-expansion", "npm:1.1.17"],\
           ["concat-map", "npm:0.0.1"]\
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:2.0.3", {\
-        "packageLocation": "./.yarn/cache/brace-expansion-npm-2.0.3-f214d9e4b4-e9dd66caaf.zip/node_modules/brace-expansion/",\
+      ["npm:2.1.4", {\
+        "packageLocation": "./.yarn/cache/brace-expansion-npm-2.1.4-10c755b3d0-11e18dc397.zip/node_modules/brace-expansion/",\
         "packageDependencies": [\
           ["balanced-match", "npm:1.0.2"],\
-          ["brace-expansion", "npm:2.0.3"]\
+          ["brace-expansion", "npm:2.1.4"]\
         ],\
         "linkType": "HARD"\
       }],\
@@ -16094,7 +16094,7 @@ const RAW_RUNTIME_STATE =
       ["npm:3.1.5", {\
         "packageLocation": "./.yarn/cache/minimatch-npm-3.1.5-86958baf50-b11a7ee577.zip/node_modules/minimatch/",\
         "packageDependencies": [\
-          ["brace-expansion", "npm:1.1.13"],\
+          ["brace-expansion", "npm:1.1.17"],\
           ["minimatch", "npm:3.1.5"]\
         ],\
         "linkType": "HARD"\
@@ -16102,7 +16102,7 @@ const RAW_RUNTIME_STATE =
       ["npm:5.1.9", {\
         "packageLocation": "./.yarn/cache/minimatch-npm-5.1.9-fc73125478-23b4feb64d.zip/node_modules/minimatch/",\
         "packageDependencies": [\
-          ["brace-expansion", "npm:2.0.3"],\
+          ["brace-expansion", "npm:2.1.4"],\
           ["minimatch", "npm:5.1.9"]\
         ],\
         "linkType": "HARD"\
@@ -16118,7 +16118,7 @@ const RAW_RUNTIME_STATE =
       ["npm:9.0.9", {\
         "packageLocation": "./.yarn/cache/minimatch-npm-9.0.9-3ee8f15008-b91fad937d.zip/node_modules/minimatch/",\
         "packageDependencies": [\
-          ["brace-expansion", "npm:2.0.3"],\
+          ["brace-expansion", "npm:2.1.4"],\
           ["minimatch", "npm:9.0.9"]\
         ],\
         "linkType": "HARD"\

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "axios": "1.18.0",
     "@babel/core": "7.29.7",
     "basic-ftp": "5.3.1",
+    "brace-expansion@^1.1.7": "1.1.17",
     "codeceptjs@npm:3.7.9/multer": "2.2.0",
     "protobufjs": "^7.6.5",
     "bfj": "9.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6133,22 +6133,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^1.1.7":
-  version: 1.1.13
-  resolution: "brace-expansion@npm:1.1.13"
+"brace-expansion@npm:1.1.17":
+  version: 1.1.17
+  resolution: "brace-expansion@npm:1.1.17"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10/b5f4329fdbe9d2e25fa250c8f866ebd054ba946179426e99b86dcccddabdb1d481f0e40ee5430032e62a7d0a6c2837605ace6783d015aa1d65d85ca72154d936
+  checksum: 10/1e2f59433dee0a52dddb9632b15757131dcc17c7a361089ee367f92b4fd72e9417f5c383d23c000840b41fe87646923519d3ed9f1ccac92930afa1b75d88096f
   languageName: node
   linkType: hard
 
 "brace-expansion@npm:^2.0.1, brace-expansion@npm:^2.0.2":
-  version: 2.0.3
-  resolution: "brace-expansion@npm:2.0.3"
+  version: 2.1.4
+  resolution: "brace-expansion@npm:2.1.4"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10/e9dd66caaf0784126e1654f1bc19adb28f3ef86f39f2226f833f7700ec727c141f6cd85eaa47bacf3426beda01c9fbc3a2f28174cf59330dc9b58ffaf9e09d96
+  checksum: 10/11e18dc39706037331abedbb742af1da733267042f94c0f08487ef1a63cee068c1859f8d5f95523869725191133eb1a69753de457ed4b76b7c187d9ea0646737
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### JIRA ticket(s)

https://tools.hmcts.net/jira/browse/S28-5082

### Change description

- Resolve the lower brace-expansion versions to be 1.1.17
- Instead of the dependabot PR https://github.com/hmcts/pre-portal/pull/1405/changes which is changing the lock file directly